### PR TITLE
ci(signing): enable release signing via Secrets

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Grant Gradle permissions
         run: chmod +x gradlew
 
+      - name: Decode Android keystore
+        if: env.ANDROID_KEYSTORE_BASE64 != ''
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > keystore.jks
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
       - name: Compute version (release)
         shell: bash
         run: |
@@ -103,6 +110,11 @@ jobs:
           echo "WM_VERSION_CODE=${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
 
       - name: Build release bundles
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: ./gradlew -PwmVersionName=${{ env.WM_VERSION_NAME }} -PwmVersionCode=${{ env.WM_VERSION_CODE }} :app:bundleRelease --no-daemon --stacktrace
 
       - name: Upload release bundles

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,20 @@ android {
     namespace = 'com.wealthmanager'
     compileSdk = 35
 
+    signingConfigs {
+        release {
+            def keystorePath = System.getenv('ANDROID_KEYSTORE_PATH') ?: new File(rootDir, 'keystore.jks').absolutePath
+            storeFile file(keystorePath)
+            storePassword System.getenv('ANDROID_KEYSTORE_PASSWORD') ?: ''
+            keyAlias System.getenv('ANDROID_KEY_ALIAS') ?: ''
+            keyPassword System.getenv('ANDROID_KEY_PASSWORD') ?: ''
+            def keystoreType = System.getenv('ANDROID_KEYSTORE_TYPE')
+            if (keystoreType != null && !keystoreType.isEmpty()) {
+                storeType keystoreType
+            }
+        }
+    }
+
     defaultConfig {
         applicationId = "com.wealthmanager"
         minSdk = 34
@@ -49,6 +63,7 @@ android {
             ndk {
                 debugSymbolLevel = 'FULL'
             }
+            signingConfig signingConfigs.release
         }
         debug {
             minifyEnabled = false


### PR DESCRIPTION
- Gradle: add signingConfigs.release reading env vars (storeType optional)\n- CI (release job): decode keystore from ANDROID_KEYSTORE_BASE64 and inject signing env\n\nOnce merged, tag v1.4.0 to trigger signed bundle build.