### PR TITLE
Fix logging import errors and dependencies

### DIFF
--- a/app/src/main/java/com/wealthmanager/debug/DebugLogManager.kt
+++ b/app/src/main/java/com/wealthmanager/debug/DebugLogManager.kt
@@ -14,6 +14,29 @@ import javax.inject.Singleton
 class DebugLogManager
     @Inject
     constructor() {
+        
+        companion object {
+            @Volatile
+            private var INSTANCE: DebugLogManager? = null
+            
+            fun getInstance(): DebugLogManager {
+                return INSTANCE ?: synchronized(this) {
+                    INSTANCE ?: DebugLogManager().also { INSTANCE = it }
+                }
+            }
+            
+            fun log(tag: String, message: String) {
+                getInstance().log(tag, message)
+            }
+            
+            fun logError(tag: String, message: String) {
+                getInstance().logError(tag, message)
+            }
+            
+            fun logError(error: String, throwable: Throwable? = null) {
+                getInstance().logError(error, throwable)
+            }
+        }
         private val logs = mutableListOf<String>()
         private val dateFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.getDefault())
 
@@ -109,27 +132,27 @@ class DebugLogManager
         }
 
         fun logUserAction(action: String) {
-            log("USER_ACTION", action)
+            this.log("USER_ACTION", action)
         }
 
         fun logNavigation(
             from: String,
             to: String,
         ) {
-            log("NAVIGATION", "From: $from -> To: $to")
+            this.log("NAVIGATION", "From: $from -> To: $to")
         }
 
         fun logError(
             error: String,
             throwable: Throwable? = null,
         ) {
-            logError("ERROR", error)
+            this.logError("ERROR", error)
             throwable?.let {
-                logError("ERROR", "Exception: ${it.message}")
+                this.logError("ERROR", "Exception: ${it.message}")
                 if (isDebugBuild()) {
-                    logError("ERROR", "Stack trace: ${it.stackTraceToString()}")
+                    this.logError("ERROR", "Stack trace: ${it.stackTraceToString()}")
                 } else {
-                    logError("ERROR", "Exception type: ${it::class.simpleName}")
+                    this.logError("ERROR", "Exception type: ${it::class.simpleName}")
                 }
             }
         }
@@ -142,7 +165,7 @@ class DebugLogManager
             status: String,
             details: String = "",
         ) {
-            log("BIOMETRIC", "$status ${if (details.isNotEmpty()) "- $details" else ""}")
+            this.log("BIOMETRIC", "$status ${if (details.isNotEmpty()) "- $details" else ""}")
         }
 
         fun logAsset(
@@ -150,7 +173,7 @@ class DebugLogManager
             assetType: String,
             details: String = "",
         ) {
-            log("ASSET", "$action $assetType ${if (details.isNotEmpty()) "- $details" else ""}")
+            this.log("ASSET", "$action $assetType ${if (details.isNotEmpty()) "- $details" else ""}")
         }
 
         fun getAllLogs(): String {
@@ -170,7 +193,7 @@ class DebugLogManager
                     getAllLogs(),
                 )
             clipboard.setPrimaryClip(clip)
-            log("DEBUG", "Logs copied to clipboard (${getLogCount()} entries)")
+            this.log("DEBUG", "Logs copied to clipboard (${getLogCount()} entries)")
         }
 
         fun clearLogs() {

--- a/app/src/main/java/com/wealthmanager/widget/TotalAssetWidgetProvider.kt
+++ b/app/src/main/java/com/wealthmanager/widget/TotalAssetWidgetProvider.kt
@@ -15,6 +15,7 @@ import com.wealthmanager.MainActivity
 import com.wealthmanager.R
 import com.wealthmanager.debug.DebugLogManager
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -32,9 +33,12 @@ import java.util.Locale
 @AndroidEntryPoint
 class TotalAssetWidgetProvider : AppWidgetProvider() {
     
+    @Inject
+    lateinit var debugLogManager: DebugLogManager
+    
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
-        DebugLogManager.log("WIDGET", "Total Asset Widget enabled")
+        debugLogManager.log("WIDGET", "Total Asset Widget enabled")
         
         // Schedule periodic updates
         WidgetUpdateScheduler.schedulePeriodicUpdate(context)
@@ -42,7 +46,7 @@ class TotalAssetWidgetProvider : AppWidgetProvider() {
     
     override fun onDisabled(context: Context) {
         super.onDisabled(context)
-        DebugLogManager.log("WIDGET", "Total Asset Widget disabled")
+        debugLogManager.log("WIDGET", "Total Asset Widget disabled")
         
         // Cancel periodic updates
         WorkManager.getInstance(context).cancelUniqueWork("widget_periodic_update")
@@ -54,7 +58,7 @@ class TotalAssetWidgetProvider : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         super.onUpdate(context, appWidgetManager, appWidgetIds)
-        DebugLogManager.log("WIDGET", "Total Asset Widget updated for ${appWidgetIds.size} widgets")
+        debugLogManager.log("WIDGET", "Total Asset Widget updated for ${appWidgetIds.size} widgets")
         
         // Update all widget instances
         for (appWidgetId in appWidgetIds) {


### PR DESCRIPTION
Fix unresolved reference errors for logging by standardizing `DebugLogManager` usage with both injected instances and static companion methods.

The `DebugLogManager` was being used inconsistently, leading to compilation errors. Some classes were attempting to call `log()` and `logError()` directly on the `DebugLogManager` class as if they were static methods, while other parts of the application were designed for dependency injection. This PR resolves these issues by adding a companion object with static methods for convenience in non-injectable contexts (like widgets) and ensuring Hilt-enabled classes correctly inject and use an instance of `DebugLogManager`. Internal calls within `DebugLogManager` itself were also corrected to use `this.` prefix.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8570f5d-65b1-4437-891b-4076920b69af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8570f5d-65b1-4437-891b-4076920b69af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

