### PR TITLE
Fix build failures due to cache service and translations

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -65,6 +65,20 @@ jobs:
           gradle-home-cache-cleanup: false
         continue-on-error: true
 
+      - name: Clear Gradle cache on failure
+        if: failure()
+        run: |
+          echo "Cache service unavailable, clearing Gradle cache..."
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches || true
+          rm -rf .gradle || true
+
+      - name: Disable Gradle caching if cache service failed
+        if: failure()
+        run: |
+          echo "Disabling Gradle caching due to cache service failure..."
+          echo "org.gradle.caching=false" >> gradle.properties
+
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2
 
@@ -200,6 +214,20 @@ jobs:
           cache-read-only: false
           gradle-home-cache-cleanup: false
         continue-on-error: true
+
+      - name: Clear Gradle cache on failure
+        if: failure()
+        run: |
+          echo "Cache service unavailable, clearing Gradle cache..."
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches || true
+          rm -rf .gradle || true
+
+      - name: Disable Gradle caching if cache service failed
+        if: failure()
+        run: |
+          echo "Disabling Gradle caching due to cache service failure..."
+          echo "org.gradle.caching=false" >> gradle.properties
 
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v2

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -34,6 +34,20 @@ jobs:
           gradle-home-cache-cleanup: false
         continue-on-error: true
 
+      - name: Clear Gradle cache on failure
+        if: failure()
+        run: |
+          echo "Cache service unavailable, clearing Gradle cache..."
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches || true
+          rm -rf .gradle || true
+
+      - name: Disable Gradle caching if cache service failed
+        if: failure()
+        run: |
+          echo "Disabling Gradle caching due to cache service failure..."
+          echo "org.gradle.caching=false" >> gradle.properties
+
       - name: Run dependency vulnerability check
         run: |
           echo "正在執行依賴項漏洞檢查..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,20 @@ jobs:
           gradle-home-cache-cleanup: false
         continue-on-error: true
 
+      - name: Clear Gradle cache on failure
+        if: failure()
+        run: |
+          echo "Cache service unavailable, clearing Gradle cache..."
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches || true
+          rm -rf .gradle || true
+
+      - name: Disable Gradle caching if cache service failed
+        if: failure()
+        run: |
+          echo "Disabling Gradle caching due to cache service failure..."
+          echo "org.gradle.caching=false" >> gradle.properties
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,6 +289,7 @@
     <string name="cd_edit_stock_asset">Edit stock asset</string>
     <string name="cd_delete_stock_asset">Delete stock asset</string>
     <string name="cd_notifications">Notifications</string>
+    <string name="cd_toggle_password_visibility">Toggle password visibility</string>
     
     <!-- Notification Permissions -->
     <string name="notification_permission_title">Enable Notifications</string>
@@ -683,6 +684,7 @@
     <!-- Search Error Messages -->
     <string name="search_error_stock_not_found">Stock code not found, please check if correct</string>
     <string name="search_error_api_limit">API request limit reached, please try again tomorrow</string>
+    <string name="search_error_api_limit_reached">API request limit reached, please try again tomorrow</string>
     <string name="search_error_network">Network connection issue, please check network settings</string>
     <string name="search_error_invalid_query">Please enter at least 1 character to search</string>
     <string name="search_error_server">Server temporarily unavailable, please try again later</string>


### PR DESCRIPTION
Add cache failure fallback to GitHub Actions workflows and missing default locale strings.

The build was failing when the external cache service was unavailable. This PR introduces steps to clear and disable Gradle caching if the `setup-gradle` action fails, allowing builds to proceed without caching and improving overall stability. It also resolves translation warnings by adding previously missing strings to the default `strings.xml` file.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4fad27c-a91b-4c27-8764-bd2627afb00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4fad27c-a91b-4c27-8764-bd2627afb00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

